### PR TITLE
#167195764 feature: Add create bus feature

### DIFF
--- a/src/controllers/Auth.js
+++ b/src/controllers/Auth.js
@@ -31,7 +31,7 @@ const Auth = {
         moment(new Date())
       ];
       const { rows } = await db.query(createQuery, values);
-      const token = createToken(rows[0].id);
+      const token = createToken(rows[0].id, rows[0].is_admin);
       return handleServerResponse(res, 201, {
         user_id: rows[0].id,
         is_admin: rows[0].is_admin,
@@ -62,7 +62,7 @@ const Auth = {
       if (!isPassword(password, rows[0].password)) {
         return handleServerResponseError(res, 403, 'Password incorrect');
       }
-      const token = createToken(rows[0].id);
+      const token = createToken(rows[0].id, rows[0].is_admin);
       return handleServerResponse(res, 200, { user_id: rows[0].id, token });
     } catch (error) {
       return handleServerError(res, error);

--- a/src/controllers/Bus.js
+++ b/src/controllers/Bus.js
@@ -1,0 +1,40 @@
+import moment from 'moment';
+import db from './db';
+import {
+  handleServerError,
+  handleServerResponse,
+  handleServerResponseError,
+} from '../helpers/utils';
+
+export default {
+  async create(req, res) {
+    const {
+      // eslint-disable-next-line camelcase
+      model, numberPlate, manufacturer, year, capacity
+    } = req.body;
+    try {
+      const createQuery = `INSERT INTO
+      Buses(model, number_plate, manufacturer, year, capacity, created_date, modified_date)
+      VALUES($1, $2, $3, $4, $5, $6, $7)
+      returning *`;
+      const values = [
+        model.trim().toLowerCase(),
+        numberPlate.trim().toLowerCase(),
+        manufacturer.trim().toLowerCase(),
+        year,
+        capacity,
+        moment(new Date()),
+        moment(new Date())
+      ];
+      const { rows } = await db.query(createQuery, values);
+      return handleServerResponse(res, 201, {
+        bus: rows[0]
+      });
+    } catch (error) {
+      if (error.routine === '_bt_check_unique') {
+        return handleServerResponseError(res, 409, `Bus with number plate:- ${numberPlate.trim().toLowerCase()} already exists`);
+      }
+      handleServerError(res, error);
+    }
+  },
+};

--- a/src/helpers/validateInput.js
+++ b/src/helpers/validateInput.js
@@ -54,8 +54,38 @@ const signinInput = (req, res, next) => {
   return next();
 };
 
+/**
+ * @function
+  * @param {*} req
+  * @param {*} res
+  * @param {*} next
+ * @description validates create bus input
+ * @returns {Response | RequestHandler} error or request handler
+ */
+const createBusInput = (req, res, next) => {
+  const {
+    // eslint-disable-next-line camelcase
+    model, manufacturer, year, numberPlate, capacity
+  } = req.body;
+  const schema = Joi.object().keys({
+    model: Joi.string().required(),
+    manufacturer: Joi.string().required(),
+    year: Joi.string().trim().required(),
+    numberPlate: Joi.string().required(),
+    capacity: Joi.number().required()
+  });
+  const result = Joi.validate({
+    model, manufacturer, year, numberPlate, capacity
+  }, schema);
+  if (result.error) {
+    return handleServerResponseError(res, 401, result.error.details[0].message);
+  }
+  return next();
+};
+
 
 export default {
   validateSignup: signupInput,
-  validateSignin: signinInput
+  validateSignin: signinInput,
+  validateCreateBus: createBusInput
 };

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ app.get('/api/v1', (req, res) => res.status(200).send({
 }));
 
 app.use('/api/v1/auth', auth);
-app.use('/api/v1/bus', bus);
+app.use('/api/v1/buses', bus);
 
 app.listen(port);
 logger().info(`app running on port ${port}`);

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import cors from 'cors';
 import morgan from 'morgan';
 import { logger } from './helpers/utils';
 import auth from './routes/auth';
+import bus from './routes/bus';
 
 dotenv.config();
 
@@ -27,6 +28,7 @@ app.get('/api/v1', (req, res) => res.status(200).send({
 }));
 
 app.use('/api/v1/auth', auth);
+app.use('/api/v1/bus', bus);
 
 app.listen(port);
 logger().info(`app running on port ${port}`);

--- a/src/routes/bus.js
+++ b/src/routes/bus.js
@@ -1,0 +1,13 @@
+import express from 'express';
+import Bus from '../controllers/Bus';
+import ValidateInput from '../helpers/validateInput';
+import { isAdmin, hasToken } from '../helpers/utils';
+
+const { create } = Bus;
+const { validateCreateBus } = ValidateInput;
+
+const router = express.Router();
+
+router.post('/', hasToken, isAdmin, validateCreateBus, create);
+
+export default router;

--- a/tests/__mocks__/bus.mocks.js
+++ b/tests/__mocks__/bus.mocks.js
@@ -1,0 +1,14 @@
+export const bus = {
+  model: 'Hiace',
+  manufacturer: 'Toyota',
+  year: '2012',
+  numberPlate: 'fh3du5',
+  capacity: 16
+};
+
+export const incompleteBus = {
+  model: 'Hiace',
+  manufacturer: 'Toyota',
+  year: '2012',
+  capacity: 16
+};

--- a/tests/controllers/bus.spec.js
+++ b/tests/controllers/bus.spec.js
@@ -1,0 +1,65 @@
+import chai from 'chai';
+import api from '../test.config';
+import {
+  normalUser, adminUser
+} from '../__mocks__/auth.mocks';
+import { bus } from '../__mocks__/bus.mocks';
+
+const { expect } = chai;
+let adminToken,
+  userToken;
+
+describe('Bus controller', () => {
+  it('should login an admin', async () => {
+    const server = await api.post('/api/v1/auth/signin')
+      .type('form')
+      .set('Content-Type', 'application/json')
+      .send(adminUser);
+    adminToken = server.body.data.token;
+    expect(server.statusCode).to.equal(200);
+  });
+
+  it('should create a new bus', async () => {
+    const server = await api.post('/api/v1/bus')
+      .type('form')
+      .set('Content-Type', 'application/json')
+      .set('x-access-token', adminToken)
+      .send(bus);
+    expect(server.statusCode).to.equal(201);
+  });
+
+  it('should not create a new bus if token is not present', async () => {
+    const server = await api.post('/api/v1/bus')
+      .type('form')
+      .set('Content-Type', 'application/json')
+      .send(bus);
+    expect(server.statusCode).to.equal(403);
+  });
+
+  it('should signin a user', async () => {
+    const server = await api.post('/api/v1/auth/signin')
+      .type('form')
+      .set('Content-Type', 'application/json')
+      .send(normalUser);
+    userToken = server.body.data.token;
+    expect(server.statusCode).to.equal(200);
+  });
+
+  it('should not create a new bus if user is not an admin', async () => {
+    const server = await api.post('/api/v1/bus')
+      .type('form')
+      .set('Content-Type', 'application/json')
+      .set('x-access-token', userToken)
+      .send(bus);
+    expect(server.statusCode).to.equal(403);
+  });
+
+  it('should not create a new bus if plate number exists', async () => {
+    const server = await api.post('/api/v1/bus')
+      .type('form')
+      .set('Content-Type', 'application/json')
+      .set('x-access-token', adminToken)
+      .send(bus);
+    expect(server.statusCode).to.equal(409);
+  });
+});

--- a/tests/controllers/bus.spec.js
+++ b/tests/controllers/bus.spec.js
@@ -20,7 +20,7 @@ describe('Bus controller', () => {
   });
 
   it('should create a new bus', async () => {
-    const server = await api.post('/api/v1/bus')
+    const server = await api.post('/api/v1/buses')
       .type('form')
       .set('Content-Type', 'application/json')
       .set('x-access-token', adminToken)
@@ -29,7 +29,7 @@ describe('Bus controller', () => {
   });
 
   it('should not create a new bus if token is not present', async () => {
-    const server = await api.post('/api/v1/bus')
+    const server = await api.post('/api/v1/buses')
       .type('form')
       .set('Content-Type', 'application/json')
       .send(bus);
@@ -46,7 +46,7 @@ describe('Bus controller', () => {
   });
 
   it('should not create a new bus if user is not an admin', async () => {
-    const server = await api.post('/api/v1/bus')
+    const server = await api.post('/api/v1/buses')
       .type('form')
       .set('Content-Type', 'application/json')
       .set('x-access-token', userToken)
@@ -55,7 +55,7 @@ describe('Bus controller', () => {
   });
 
   it('should not create a new bus if plate number exists', async () => {
-    const server = await api.post('/api/v1/bus')
+    const server = await api.post('/api/v1/buses')
       .type('form')
       .set('Content-Type', 'application/json')
       .set('x-access-token', adminToken)


### PR DESCRIPTION
#### What does this PR do?
- Adds feature to add buses to the system

#### Description
- add endpoint to create bus

- write test to check for edge cases

- only admin should have access to the endpoint

#### How should this be manually tested?
- On Postman access the endpoint `POST: /api/v1/buses`
- Set the header `x-access-token` to the  token gotten from the signup or signin endpoint
- Pass in `numberPlate`, `manufacturer`, `model`, `year`, `capacity` to the body
- check for response

#### Any background context you want to provide?
- For trips to be created buses have to be in place first so as to know which bus is assigned to a trip

#### What are the relevant pivotal tracker stories?
- https://www.pivotaltracker.com/story/show/167195764
[Finishes #167195764]